### PR TITLE
Default Embed Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 build
 *.egg-info
+.venv

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+dev:
+	pip install -e ".[dev]"
+	python3 validator/post-install.py
+
 lint:
 	ruff check .
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Note:
     | --- | --- | --- | --- |
     | `query_function` | _Optional[Callable]_ | A callable that takes a string and returns a list of (chunk, score) tuples. In order to use this validator, you must provide either a `query_function` or `sources` with an `embed_function` in the metadata. The query_function should take a string as input and return a list of (chunk, score) tuples. The chunk is a string and the score is a float representing the cosine distance between the chunk and the input string. The list should be sorted in ascending order by score. | None |
     | `sources` | *Optional[List[str]]* | The source text. In order to use this validator, you must provide either a `query_function` or `sources` with an `embed_function` in the metadata. | None |
-    | `embed_function` | *Optional[Callable]* | A callable that creates embeddings for the sources. Must accept a list of strings and return an np.array of floats. | None |
+    | `embed_function` | *Optional[Callable]* | A callable that creates embeddings for the sources. Must accept a list of strings and return an np.array of floats. | sentence-transformer's `paraphrase-MiniLM-L6-v2` |
   
 
 </ul>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">= 3.8.1"
 dependencies = [
     "guardrails-ai>=0.4.0",
     "numpy",
-    "nltk"
+    "nltk",
+    "sentence-transformers"
 ]
 
 [project.optional-dependencies]

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -59,8 +59,7 @@ class ValidatorTestObject(BaseModel):
             }
             """,
             {
-                "sources": SOURCES,
-                "embed_function": embed_function
+                "sources": SOURCES
             }
         )
     ],

--- a/validator/post-install.py
+++ b/validator/post-install.py
@@ -1,4 +1,5 @@
 import nltk
+from sentence_transformers import SentenceTransformer
 
 # Download NLTK data if not already present
 try:
@@ -6,3 +7,6 @@ try:
 except LookupError:
     nltk.download("punkt")
 print("NLTK stuff loaded successfully.")
+
+# Load model for default embedding function
+SentenceTransformer("paraphrase-MiniLM-L6-v2")


### PR DESCRIPTION
This PR adds a default `embed_function` that can be used when one is not passed by the user in the metadata.  This both lowers barrier to entry for using this validators, and other like it, as well as enables easier integration into the Hub playground.

Related to https://github.com/guardrails-ai/validator-hub-ui/pull/9